### PR TITLE
Use the oficial qemu-virgil

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -339,7 +339,7 @@ parts:
   qemu:
     plugin: nil
     after: [ osinfo-db ]
-    stage-snaps: [ qemu-virgil-tmp-work/latest/edge ]
+    stage-snaps: [ qemu-virgil/latest/edge ]
     stage-packages:
       - dnsmasq-base
 


### PR DESCRIPTION
For the initial Core22 build, I used my own snap until the oficial applied the needed patch. Now that it has applied them, this can be changed.

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please check only the options that are relevant.

- [ ] General Maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**Test Configuration**:

* OS (please include version):
* Any other relevant environment information:

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings

