### PR TITLE
Revert updates

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,6 +5,8 @@ confinement: strict
 base: core22
 
 layout:
+  /usr/share/OVMF:
+    bind: $SNAP/usr/share/OVMF
   /usr/share/gnome-boxes:
     bind: $SNAP/usr/share/gnome-boxes
   /usr/share/osinfo:
@@ -76,8 +78,11 @@ parts:
   libvirt:
     source: https://gitlab.com/libvirt/libvirt.git
     source-depth: 1
-    source-tag: 'v9.5.0'
+    source-tag: 'v6.0.0'
     plugin: autotools
+# ext:updatesnap
+#   version-format:
+#     lower-than: 6.1.0
     build-packages:
       - libxml2-dev
       - libncurses5-dev
@@ -159,8 +164,10 @@ parts:
       - libyajl2
     build-environment:
       - CFLAGS: "-Wno-error"
-    override-build: |
+    override-pull: |
+      craftctl default
       git apply $CRAFT_PROJECT_DIR/patches/libvirt-qemu.patch
+    override-build: |
       mkdir build && cd build
       ../autogen.sh --prefix=/usr --sysconfdir=/etc --localstatedir=/var --with-qemu
       sed -i "s# docs # #g" Makefile
@@ -173,6 +180,9 @@ parts:
   libvirt-glib:
     source: https://github.com/libvirt/libvirt-glib.git
     source-tag: "v4.0.0"
+# ext:updatesnap
+#   version-format:
+#     lower-than: 5.0.0
     after: [ libvirt ]
     source-depth: 1
     plugin: meson
@@ -186,7 +196,10 @@ parts:
 
   tracker:
     source: https://gitlab.gnome.org/GNOME/tracker.git
-    source-tag: '3.5.3'
+    source-tag: '3.3.3'
+# ext:updatesnap
+#   version-format:
+#     lower-than: 3.4.0
     source-depth: 1
     plugin: meson
     meson-parameters:
@@ -212,8 +225,11 @@ parts:
   gnome-boxes:
     after: [ libvirt-glib, tracker ]
     source: https://gitlab.gnome.org/GNOME/gnome-boxes.git
-    source-tag: '43.5'
+    source-tag: '42.3'
     source-depth: 1
+# ext:updatesnap
+#   version-format:
+#     lower-than: 43.0
     parse-info: [usr/share/metainfo/org.gnome.Boxes.appdata.xml]
     plugin: meson
     meson-parameters:
@@ -329,13 +345,13 @@ parts:
       - osinfo-db-tools
       - wget
     override-build: |
-      snapcraftctl build
-      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/share/osinfo
-      tar xf osinfo-db-*.tar.xz --strip-components=1 -C $SNAPCRAFT_PART_INSTALL/usr/share/osinfo
-      cp $SNAPCRAFT_PROJECT_DIR/ubuntu-daily.xml $SNAPCRAFT_PART_INSTALL/usr/share/osinfo/os/ubuntu.com/
+      craftctl default
+      mkdir -p $CRAFT_PART_INSTALL/usr/share/osinfo
+      tar xf osinfo-db-*.tar.xz --strip-components=1 -C $CRAFT_PART_INSTALL/usr/share/osinfo
+      cp $CRAFT_PROJECT_DIR/ubuntu-daily.xml $CRAFT_PART_INSTALL/usr/share/osinfo/os/ubuntu.com/
       # fix broken focal revision
       FOCAL="$(wget -O- -q http://changelogs.ubuntu.com/meta-release-lts | grep "Version: 20.04" | cut -d' ' -f2)"
-      sed -i "s/20.04.3/$FOCAL/" $SNAPCRAFT_PART_INSTALL/usr/share/osinfo/os/ubuntu.com/ubuntu-20.04.xml
+      sed -i "s/20.04.3/$FOCAL/" $CRAFT_PART_INSTALL/usr/share/osinfo/os/ubuntu.com/ubuntu-20.04.xml
 
   qemu:
     plugin: nil


### PR DESCRIPTION
udpatesnap updated the versions of some parts, and that broke the build. This patch reverts these changes and locks the versions, to only allow to update manually.

It also binds the OVMF folder to allow to boot UEFI OS.

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please check only the options that are relevant.

- [ ] General Maintenance
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**Test Configuration**:

* OS (please include version):
* Any other relevant environment information:

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

