### PR TITLE
snap: Bump version to gnome-boxes-48

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -341,7 +341,7 @@ parts:
       - libvirt-glib
       - libosinfo
     source: https://gitlab.gnome.org/GNOME/gnome-boxes.git
-    source-tag: '47.0'
+    source-tag: '48.0'
     source-depth: 1
 # ext:updatesnap
 #   version-format:


### PR DESCRIPTION
In order to build https://github.com/ubuntu/gnome-sdk/pull/294 is required.

UDENG-6680